### PR TITLE
Fixed deprecated warning for simple_form.

### DIFF
--- a/lib/rails-jquery-autocomplete/simple_form_plugin.rb
+++ b/lib/rails-jquery-autocomplete/simple_form_plugin.rb
@@ -17,11 +17,11 @@ module SimpleForm
     class AutocompleteInput < Base
       include Autocomplete
 
-      def input
+      def input(wrapper_options)
         @builder.autocomplete_field(
           attribute_name,
           options[:url],
-          rewrite_autocomplete_option
+          merge_wrapper_options(rewrite_autocomplete_option, wrapper_options)
         )
       end
 
@@ -38,7 +38,7 @@ module SimpleForm
     class AutocompleteCollectionInput < CollectionInput
       include Autocomplete
 
-      def input
+      def input(wrapper_options)
         # http://www.codeofficer.com/blog/entry/form_builders_in_rails_discovering_field_names_and_ids_for_javascript/
         hidden_id = "#{object_name}_#{attribute_name}_hidden".gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").sub(/_$/, "")
         id_element = options[:id_element]
@@ -48,7 +48,7 @@ module SimpleForm
           id_element = "#" + hidden_id
         end
         options[:id_element] = id_element
-        autocomplete_options = rewrite_autocomplete_option
+        autocomplete_options = merge_wrapper_options(rewrite_autocomplete_option, wrapper_options)
         #
         label_method, value_method = detect_collection_methods
         association = object.send(reflection.name)


### PR DESCRIPTION
See plataformatec/simple_form#997 for an
explanation. Fixes issue #284 .
But at the same time it breaks the testing suite since this only works for newer simple form versions. The testing suite is using simple_form 1.5.2 at the time of writing.

See also pull request for old gem: https://github.com/crowdint/rails3-jquery-autocomplete/pull/287