### PR TITLE
Require only jquery-ui/autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Just add it to your app/assets/javascripts/application.js file
 
     //= require jquery
     //= require jquery_ujs
-    //= require jquery-ui
+    //= require jquery-ui/autocomplete
     //= require autocomplete-rails
 
 ## Usage


### PR DESCRIPTION
Seems there is no need to require the whole `jquery-ui` instead of just `jquery-ui/autocomplete`. The second one contains all needed dependencies.

Resolves #21.