### PR TITLE
Added option to make autocomplete case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ e.g `:scopes => [:scope1, :scope2]`
 By default autocomplete uses method name as column name. Now it can be specified using column_name options
 `:column_name => 'name'`
 
+#### :case_sensitive
+
+Normally autocomplete performs a case insentive search. In cases where this is not desirable, or causes too high
+a performance penalty, search can be made case sensitive by specifying `:case_sensitive => true`
+
 #### json encoder
 
 Autocomplete uses Yajl as JSON encoder/decoder, but you can specify your own

--- a/lib/rails-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails-jquery-autocomplete/orm/active_record.rb
@@ -50,13 +50,15 @@ module RailsJQueryAutocomplete
       def get_autocomplete_where_clause(model, term, method, options)
         table_name = model.table_name
         is_full_search = options[:full]
-        like_clause = (postgres?(model) ? 'ILIKE' : 'LIKE')
+        is_case_sensitive_search = options[:case_sensitive]
+        like_clause = (postgres?(model) && !is_case_sensitive_search ? 'ILIKE' : 'LIKE')
+        column_transform = is_case_sensitive_search ? '' : 'LOWER'
         if options[:hstore]
-          ["LOWER(#{table_name}.#{method} -> '#{options[:hstore][:key]}') LIKE ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
+          ["#{column_transform}(#{table_name}.#{method} -> '#{options[:hstore][:key]}') LIKE #{column_transform}(?)", "#{(is_full_search ? '%' : '')}#{term}%"]
         elsif sqlite?
-          ["LOWER(#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
+          ["#{column_transform}(#{method}) #{like_clause} #{column_transform}(?)", "#{(is_full_search ? '%' : '')}#{term}%"]
         else
-          ["LOWER(#{table_name}.#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
+          ["#{column_transform}(#{table_name}.#{method}) #{like_clause} #{column_transform}(?)", "#{(is_full_search ? '%' : '')}#{term}%"]
         end
       end
 

--- a/lib/rails-jquery-autocomplete/orm/mongo_mapper.rb
+++ b/lib/rails-jquery-autocomplete/orm/mongo_mapper.rb
@@ -18,12 +18,14 @@ module RailsJQueryAutocomplete
         method         = parameters[:method]
         options        = parameters[:options]
         is_full_search = options[:full]
+        is_case_sensitive_search = options[:case_sensitive]
         term           = parameters[:term]
         limit          = get_autocomplete_limit(options)
         order          = mongo_mapper_get_autocomplete_order(method, options)
 
         search = (is_full_search ? '.*' : '^') + term + '.*'
-				items  = model.where(method.to_sym => /#{search}/i).limit(limit).sort(order)
+        search = Regexp.new(search, !is_case_sensitive_search)
+				items  = model.where(method.to_sym => search).limit(limit).sort(order)
 			end
 		end
 	end

--- a/lib/rails-jquery-autocomplete/orm/mongoid.rb
+++ b/lib/rails-jquery-autocomplete/orm/mongoid.rb
@@ -18,6 +18,7 @@ module RailsJQueryAutocomplete
         method         = parameters[:method]
         options        = parameters[:options]
         is_full_search = options[:full]
+        is_case_sensitive_search = options[:case_sensitive]
         term           = parameters[:term]
         limit          = get_autocomplete_limit(options)
         order          = mongoid_get_autocomplete_order(method, options)
@@ -27,7 +28,8 @@ module RailsJQueryAutocomplete
         else
           search = '^' + Regexp.escape(term)
         end
-        items  = model.where(method.to_sym => /#{search}/i).limit(limit).order_by(order)
+        search = Regexp.new(search, !is_case_sensitive_search)
+        items  = model.where(method.to_sym => search).limit(limit).order_by(order)
       end
     end
   end

--- a/test/lib/rails-jquery-autocomplete/orm/active_record_test.rb
+++ b/test/lib/rails-jquery-autocomplete/orm/active_record_test.rb
@@ -130,14 +130,14 @@ module RailsJQueryAutocomplete
         context 'Not Postgres' do
           should 'return options for where' do
             mock(self).postgres?(@model) { false }
-            assert_equal ["LOWER(table_name.method) LIKE ?", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
+            assert_equal ["LOWER(table_name.method) LIKE LOWER(?)", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
           end
         end
 
         context 'Postgres' do
           should 'return options for where with ILIKE' do
             mock(self).postgres?(@model) { true }
-            assert_equal ["LOWER(table_name.method) ILIKE ?", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
+            assert_equal ["LOWER(table_name.method) ILIKE LOWER(?)", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
           end
         end
 
@@ -146,7 +146,7 @@ module RailsJQueryAutocomplete
             mock(self).postgres?(@model) { true }
             @options[:hstore] = {method: :hsmethod, key: :hskey}
             @method = :hsmethod
-            assert_equal ["LOWER(table_name.hsmethod -> 'hskey') LIKE ?", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
+            assert_equal ["LOWER(table_name.hsmethod -> 'hskey') LIKE LOWER(?)", "query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
           end
         end
 
@@ -154,7 +154,7 @@ module RailsJQueryAutocomplete
           should 'return options for where with the term sourrounded by %%' do
             mock(self).postgres?(@model) { false }
             @options[:full] = true
-            assert_equal ["LOWER(table_name.method) LIKE ?", "%query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
+            assert_equal ["LOWER(table_name.method) LIKE LOWER(?)", "%query%"], get_autocomplete_where_clause(@model, @term, @method, @options)
           end
         end
       end


### PR DESCRIPTION
In some cases case sensitive search is preferred or just a lot faster. To allow for that, I added the `case_sensitive` option to the `autocomplete` method.

My app has a table with a million domain names. Running a case insensitive search is very slow, because there are no indices to be used. Creating an expression index just for autocompletion seems a little silly, especially since all domain names are lowercase already anyways. 

Performance benefit of not using `LOWER` in query is huge. Others may benefit as well.