### PR TITLE
Return a HashWithIndifferentAccess from json_for_autocomplete

### DIFF
--- a/lib/rails-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails-jquery-autocomplete/autocomplete.rb
@@ -98,7 +98,7 @@ module RailsJQueryAutocomplete
     #
     def json_for_autocomplete(items, method, extra_data=[])
       items = items.collect do |item|
-        hash = {"id" => item.id.to_s, "label" => item.send(method), "value" => item.send(method)}
+        hash = HashWithIndifferentAccess.new({"id" => item.id.to_s, "label" => item.send(method), "value" => item.send(method)})
         extra_data.each do |datum|
           hash[datum] = item.send(datum)
         end if extra_data

--- a/test/lib/rails-jquery-autocomplete/autocomplete_test.rb
+++ b/test/lib/rails-jquery-autocomplete/autocomplete_test.rb
@@ -62,6 +62,17 @@ module RailsJQueryAutocomplete
         assert_equal response["label"], "Object Name"
       end
 
+      should 'return an instance of HashWithIndifferentAccess' do
+        item = mock(Object)
+        mock(item).send(:name).times(2) { 'Object Name' }
+        mock(item).id { 1 }
+        items    = [item]
+        response = self.json_for_autocomplete(items, :name).first
+        assert_equal response.is_a?(HashWithIndifferentAccess), true
+        assert_equal response["id"], "1"
+        assert_equal response[:id], "1"
+      end
+
       context 'with extra data' do
         should 'add that extra data to result' do
           item = mock(Object)


### PR DESCRIPTION
The hash created in #json_for_autocomplete has the id, label, and name keys stringified, but the extra_data option symbolizes its keys. This pull request creates a HashWithIndifferentAccess so keys can be accessed through symbols and strings.