### PR TITLE
Allow use of pluck instead of select

### DIFF
--- a/lib/rails-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails-jquery-autocomplete/autocomplete.rb
@@ -97,13 +97,19 @@ module RailsJQueryAutocomplete
     # Hash also includes a key/value pair for each method in extra_data
     #
     def json_for_autocomplete(items, method, extra_data=[])
-      items = items.collect do |item|
-        hash = HashWithIndifferentAccess.new({"id" => item.id.to_s, "label" => item.send(method), "value" => item.send(method)})
-        extra_data.each do |datum|
-          hash[datum] = item.send(datum)
-        end if extra_data
-        # TODO: Come back to remove this if clause when test suite is better
-        hash
+      if items.first && items.first.kind_of?(Hash)
+        items.each do |item|
+          item['label'] = item['value'] = item[method.to_s]
+        end
+      else
+        items = items.collect do |item|
+          hash = HashWithIndifferentAccess.new({"id" => item.id.to_s, "label" => item.send(method), "value" => item.send(method)})
+          extra_data.each do |datum|
+            hash[datum] = item.send(datum)
+          end if extra_data
+          # TODO: Come back to remove this if clause when test suite is better
+          hash
+        end
       end
       if block_given?
         yield(items)

--- a/lib/rails-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails-jquery-autocomplete/orm/active_record.rb
@@ -36,7 +36,7 @@ module RailsJQueryAutocomplete
         items = items.where(where) unless where.blank?
         if select_method == :pluck
           columns = get_autocomplete_select_clause(model, method, options)
-          items = items.pluck(*columns) unless options[:full_model]
+          items = items.pluck(*columns)
           columns = columns.map{|column| column.sub(/^#{model.table_name}\./, '')}
           items = items.map{|item| Hash[columns.zip(item)]}
         end

--- a/test/lib/rails-jquery-autocomplete/autocomplete_test.rb
+++ b/test/lib/rails-jquery-autocomplete/autocomplete_test.rb
@@ -54,6 +54,7 @@ module RailsJQueryAutocomplete
       should 'parse items to JSON' do
         item = mock(Object)
         mock(item).send(:name).times(2) { 'Object Name' }
+        stub(item).kind_of?(Hash){ false }
         mock(item).id { 1 }
         items    = [item]
         response = self.json_for_autocomplete(items, :name).first
@@ -65,6 +66,7 @@ module RailsJQueryAutocomplete
       should 'return an instance of HashWithIndifferentAccess' do
         item = mock(Object)
         mock(item).send(:name).times(2) { 'Object Name' }
+        stub(item).kind_of?(Hash){ false }
         mock(item).id { 1 }
         items    = [item]
         response = self.json_for_autocomplete(items, :name).first
@@ -77,6 +79,7 @@ module RailsJQueryAutocomplete
         should 'add that extra data to result' do
           item = mock(Object)
           mock(item).send(:name).times(2) { 'Object Name' }
+          stub(item).kind_of?(Hash){ false }
           mock(item).id { 1 }
           mock(item).send("extra") { 'Object Extra ' }
 


### PR DESCRIPTION
this in conjunction with using a scope that joins
an association allows fetching attributes of associated
records.

class Organization
  belongs_to :contact

  scope :with_contact, -> { joins(:contact) }
end

autocomplete :organization, :name, extra_data: ['contacts.email'],
select_method: :pluck, scopes: [:with_contact]

f.autocomplete_field :name,
autocomplete_organization_name_product_path, update_elements: {id:
'#products_organization_attributes_id', 'contacts.email':
'#products_contact_attributes_email'}


I have not yet written any tests, let me know if you are interested in including this and I will try to provide some coverage.