### PR TITLE
Fix #45 Make scopes option can accepts Proc

### DIFF
--- a/lib/rails-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails-jquery-autocomplete/orm/active_record.rb
@@ -24,12 +24,19 @@ module RailsJQueryAutocomplete
 
         items = (::Rails::VERSION::MAJOR * 10 + ::Rails::VERSION::MINOR) >= 40 ? model.where(nil) : model.scoped
 
-        scopes.each { |scope| items = items.send(scope) } unless scopes.empty?
-
         items = items.select(get_autocomplete_select_clause(model, method, options)) unless options[:full_model]
         items = items.where(get_autocomplete_where_clause(model, term, method, options)).
             limit(limit).order(order)
         items = items.where(where) unless where.blank?
+
+        scopes.each do |scope|
+          items = case scope
+                  when String
+                    items.send(scope)
+                  when Proc
+                    items.instance_exec(&scope)
+                  end
+        end
 
         items
       end


### PR DESCRIPTION
Scopes can also override the select and where.
So you can use code like following to query unique result.

    autocomplete :item, :brand, full: true, scopes: [-> { unscope(:select).select('MIN(id) as id, brand').group(:brand) }]