### PR TITLE
Fix JQuery autocomplete widget typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Just add it to your app/assets/javascripts/application.js file
 
     //= require jquery
     //= require jquery_ujs
-    //= require jquery-ui/autocomplete
+    //= require jquery-ui/widgets/autocomplete
     //= require autocomplete-rails
 
 ## Usage


### PR DESCRIPTION
Hey there! FYI I found out that JQUery UI has had a directory change 

The new directory structure for JQuery UI is
`//= require jquery-ui/widgets/autocomplete`

Instead of what is currently listed:
//= require jquery-ui/autocomplete

See here for details:  https://github.com/jquery-ui-rails/jquery-ui-rails#widgets